### PR TITLE
Show arcminutes in degree positions (DD°MM')

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chart2txt",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chart2txt",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chart2txt",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Convert astrological chart data to human-readable text",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/core/analysis.ts
+++ b/src/core/analysis.ts
@@ -20,15 +20,12 @@ import { calculateAspects, calculateMultichartAspects } from './aspects';
 import { detectAspectPatterns } from './aspectPatterns';
 import { detectStelliums } from './stelliums';
 import { getPlanetPositions } from '../utils/formatting';
+import { normalizeDegree } from './astrology';
 import { calculateSignDistributions } from './signDistributions';
 import { calculateDispositors } from './dispositors';
 import { calculateHouseOverlays } from '../utils/houseCalculations';
 
 // Helper functions
-
-function normalizeDegree(degree: number): number {
-  return ((degree % 360) + 360) % 360;
-}
 
 function circularMeanDegrees(degrees: number[]): number {
   if (degrees.length === 0) {

--- a/src/core/aspectPatterns.ts
+++ b/src/core/aspectPatterns.ts
@@ -11,7 +11,7 @@ import {
   Kite,
   UnionedPoint,
 } from '../types';
-import { getDegreeSign } from './astrology';
+import { getDegreeSign, normalizeDegree } from './astrology';
 
 /**
  * Create a consistent key for planet+chart combinations
@@ -62,7 +62,7 @@ function pointToPlanetPosition(
     houseCusps && houseCusps.length === 12
       ? (() => {
           // Simple house calculation without importing the utility
-          const normalizedDegree = point.degree % 360;
+          const normalizedDegree = normalizeDegree(point.degree);
           for (let i = 0; i < 12; i++) {
             const currentCusp = houseCusps[i];
             const nextCusp = houseCusps[(i + 1) % 12];

--- a/src/formatters/text/sections/angles.ts
+++ b/src/formatters/text/sections/angles.ts
@@ -1,4 +1,5 @@
 import { getDegreeSign, getDegreeInSign } from '../../../core/astrology';
+import { formatDegMin } from '../../../utils/formatting';
 
 /**
  * Generates the [ANGLES] section of the chart output.
@@ -14,7 +15,7 @@ export function generateAnglesOutput(
 
   if (ascDegree !== undefined) {
     output.push(
-      `Ascendant: ${Math.floor(getDegreeInSign(ascDegree))}° ${getDegreeSign(
+      `Ascendant: ${formatDegMin(getDegreeInSign(ascDegree))} ${getDegreeSign(
         ascDegree
       )}`
     );
@@ -24,7 +25,7 @@ export function generateAnglesOutput(
 
   if (mcDegree !== undefined) {
     output.push(
-      `Midheaven: ${Math.floor(getDegreeInSign(mcDegree))}° ${getDegreeSign(
+      `Midheaven: ${formatDegMin(getDegreeInSign(mcDegree))} ${getDegreeSign(
         mcDegree
       )}`
     );

--- a/src/formatters/text/sections/aspectPatterns.ts
+++ b/src/formatters/text/sections/aspectPatterns.ts
@@ -1,6 +1,6 @@
 import { AspectPattern, PlanetPosition } from '../../../types';
 import { getDegreeInSign } from '../../../core/astrology';
-import { getOrdinal } from '../../../utils/formatting';
+import { formatDegMin, getOrdinal } from '../../../utils/formatting';
 
 /**
  * Format a planet position for display
@@ -10,12 +10,12 @@ function formatPlanetPosition(
   includeHouse = false,
   showChartNames = true
 ): string {
-  const degInSign = Math.floor(getDegreeInSign(planet.degree));
+  const degInSign = formatDegMin(getDegreeInSign(planet.degree));
   const houseStr =
     includeHouse && planet.house ? ` (${getOrdinal(planet.house)} house)` : '';
   const chartPrefix =
     showChartNames && planet.chartName ? `${planet.chartName}'s ` : '';
-  return `${chartPrefix}${planet.name} ${degInSign}° ${planet.sign}${houseStr}`;
+  return `${chartPrefix}${planet.name} ${degInSign} ${planet.sign}${houseStr}`;
 }
 
 /**

--- a/src/formatters/text/sections/houses.ts
+++ b/src/formatters/text/sections/houses.ts
@@ -1,5 +1,5 @@
 import { getDegreeSign, getDegreeInSign } from '../../../core/astrology';
-import { getOrdinal } from '../../../utils/formatting';
+import { formatDegMin, getOrdinal } from '../../../utils/formatting';
 
 /**
  * Generates the [HOUSE CUSPS] section of the chart output.
@@ -23,17 +23,17 @@ export function generateHousesOutput(houseCusps?: number[]): string[] {
     const rightCusp = houseCusps[rightHouseIndex];
 
     const leftSign = getDegreeSign(leftCusp);
-    const leftDegInSign = Math.floor(getDegreeInSign(leftCusp));
+    const leftDegInSign = formatDegMin(getDegreeInSign(leftCusp));
     const leftHouseLabel = getOrdinal(leftHouseIndex + 1) + ' house';
 
     const rightSign = getDegreeSign(rightCusp);
-    const rightDegInSign = Math.floor(getDegreeInSign(rightCusp));
+    const rightDegInSign = formatDegMin(getDegreeInSign(rightCusp));
     const rightHouseLabel = getOrdinal(rightHouseIndex + 1) + ' house';
 
     // Pad the left side to align columns
-    const leftPart = `${leftHouseLabel}: ${leftDegInSign}° ${leftSign}`;
-    const paddedLeftPart = leftPart.padEnd(24); // Adjust padding as needed
-    const rightPart = `${rightHouseLabel}: ${rightDegInSign}° ${rightSign}`;
+    const leftPart = `${leftHouseLabel}: ${leftDegInSign} ${leftSign}`;
+    const paddedLeftPart = leftPart.padEnd(28); // Adjust padding as needed
+    const rightPart = `${rightHouseLabel}: ${rightDegInSign} ${rightSign}`;
 
     output.push(`${paddedLeftPart} ${rightPart}`);
   }

--- a/src/formatters/text/sections/planets.ts
+++ b/src/formatters/text/sections/planets.ts
@@ -1,5 +1,5 @@
 import { PlanetPosition } from '../../../types';
-import { getOrdinal } from '../../../utils/formatting';
+import { formatDegMin, getOrdinal } from '../../../utils/formatting';
 import { formatPlanetWithDignities } from '../../../core/dignities';
 
 /**
@@ -14,7 +14,7 @@ export function generatePlanetsOutput(placements: PlanetPosition[]): string[] {
   placements.forEach((planet) => {
     const dignities = formatPlanetWithDignities(planet);
     const retrograde = planet.speed && planet.speed < 0 ? ' Retrograde' : '';
-    let line = `${planet.name}: ${Math.floor(planet.degree % 30)}° ${
+    let line = `${planet.name}: ${formatDegMin(planet.degree % 30)} ${
       planet.sign
     }${retrograde} ${dignities}`;
 

--- a/src/formatters/text/sections/planets.ts
+++ b/src/formatters/text/sections/planets.ts
@@ -1,6 +1,7 @@
 import { PlanetPosition } from '../../../types';
 import { formatDegMin, getOrdinal } from '../../../utils/formatting';
 import { formatPlanetWithDignities } from '../../../core/dignities';
+import { getDegreeInSign } from '../../../core/astrology';
 
 /**
  * Generates the [PLANETS] section of the chart output.
@@ -14,7 +15,7 @@ export function generatePlanetsOutput(placements: PlanetPosition[]): string[] {
   placements.forEach((planet) => {
     const dignities = formatPlanetWithDignities(planet);
     const retrograde = planet.speed && planet.speed < 0 ? ' Retrograde' : '';
-    let line = `${planet.name}: ${formatDegMin(planet.degree % 30)} ${
+    let line = `${planet.name}: ${formatDegMin(getDegreeInSign(planet.degree))} ${
       planet.sign
     }${retrograde} ${dignities}`;
 

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -1,9 +1,12 @@
 import { Point, PlanetPosition } from '../types';
-import { ZODIAC_SIGNS } from '../constants';
+import { getDegreeSign, normalizeDegree } from '../core/astrology';
 
-function normalizeDegree(degree: number): number {
-  return ((degree % 360) + 360) % 360;
-}
+const MINUTES_PER_DEGREE = 60;
+const MINUTES_PER_SIGN = 30 * MINUTES_PER_DEGREE;
+// 1e-9 degree-minutes ≈ 3.6 microarcseconds — far below the resolution of any
+// astronomical ephemeris, but large enough to absorb double-precision % 30
+// rounding error at exact minute boundaries (e.g. 200 + 1/60).
+const MINUTE_FLOOR_EPSILON = 1e-9;
 
 /**
  * Converts a number to its ordinal form (1st, 2nd, 3rd, etc.)
@@ -17,22 +20,37 @@ export function getOrdinal(num: number): string {
 }
 
 /**
- * Formats a degree-in-sign value as "DD°MM'" with floored arcminutes.
+ * Formats a degree-in-sign value as "DD°MM'" with truncated arcminutes.
  * E.g. 15.3833 -> "15°22'", 0.5 -> "0°30'".
  * Minutes are zero-padded for stable column widths.
+ * A tiny epsilon prevents exact minute boundaries from underflowing due to
+ * floating-point representation after modulo arithmetic.
  * @param degreeInSign Position within the sign (0-30).
  * @returns Formatted "DD°MM'" string.
  */
 export function formatDegMin(degreeInSign: number): string {
-  const totalMinutes = Math.floor(degreeInSign * 60);
-  const deg = Math.floor(totalMinutes / 60);
-  const min = totalMinutes % 60;
+  if (!isFinite(degreeInSign)) {
+    throw new Error(`Invalid degree-in-sign value: ${degreeInSign}`);
+  }
+
+  let normalizedDegreeInSign = degreeInSign % 30;
+  if (normalizedDegreeInSign < 0) {
+    normalizedDegreeInSign += 30;
+  }
+
+  const totalMinutes = Math.min(
+    Math.floor(
+      normalizedDegreeInSign * MINUTES_PER_DEGREE + MINUTE_FLOOR_EPSILON
+    ),
+    MINUTES_PER_SIGN - 1
+  );
+  const deg = Math.floor(totalMinutes / MINUTES_PER_DEGREE);
+  const min = totalMinutes % MINUTES_PER_DEGREE;
   return `${deg}°${min.toString().padStart(2, '0')}'`;
 }
 
 export function getSign(degree: number): string {
-  const signIndex = Math.floor(degree / 30);
-  return ZODIAC_SIGNS[signIndex];
+  return getDegreeSign(degree);
 }
 
 export function getHouse(degree: number, houseCusps: number[]): number {

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -16,6 +16,20 @@ export function getOrdinal(num: number): string {
   return num + (suffix[(v - 20) % 10] || suffix[v] || suffix[0]);
 }
 
+/**
+ * Formats a degree-in-sign value as "DD°MM'" with floored arcminutes.
+ * E.g. 15.3833 -> "15°22'", 0.5 -> "0°30'".
+ * Minutes are zero-padded for stable column widths.
+ * @param degreeInSign Position within the sign (0-30).
+ * @returns Formatted "DD°MM'" string.
+ */
+export function formatDegMin(degreeInSign: number): string {
+  const totalMinutes = Math.floor(degreeInSign * 60);
+  const deg = Math.floor(totalMinutes / 60);
+  const min = totalMinutes % 60;
+  return `${deg}°${min.toString().padStart(2, '0')}'`;
+}
+
 export function getSign(degree: number): string {
   const signIndex = Math.floor(degree / 30);
   return ZODIAC_SIGNS[signIndex];

--- a/tests/basic-formatting.test.ts
+++ b/tests/basic-formatting.test.ts
@@ -15,9 +15,9 @@ describe('Basic Formatting', () => {
       const result = chart2txt(data, { includeAspectPatterns: true });
 
       expect(result).toContain('[PLANETS]');
-      expect(result).toContain('Sun: 5° Taurus');
-      expect(result).toContain('Moon: 0° Leo');
-      expect(result).toContain('Mercury: 15° Gemini');
+      expect(result).toContain("Sun: 5°00' Taurus");
+      expect(result).toContain("Moon: 0°00' Leo");
+      expect(result).toContain("Mercury: 15°00' Gemini");
     });
   });
 
@@ -38,8 +38,8 @@ describe('Basic Formatting', () => {
       expect(result).toContain('house_system: equal');
       expect(result).toContain('[PLANETS]');
       // Note: House positions are not shown without houseCusps data in current implementation
-      expect(result).toContain('Sun: 5° Taurus');
-      expect(result).toContain('Moon: 0° Leo');
+      expect(result).toContain("Sun: 5°00' Taurus");
+      expect(result).toContain("Moon: 0°00' Leo");
     });
 
     test('uses chart-level house system metadata when settings do not override it', () => {
@@ -85,8 +85,8 @@ describe('Basic Formatting', () => {
       expect(result).toContain('house_system: whole_sign');
       expect(result).toContain('[PLANETS]');
       // With this ASC at 6° Aries and these house cusps, actual house positions are different
-      expect(result).toContain('Sun: 5° Taurus [Ruler: Venus], 1st house');
-      expect(result).toContain('Moon: 0° Leo [Ruler: Sun], 4th house');
+      expect(result).toContain("Sun: 5°00' Taurus [Ruler: Venus], 1st house");
+      expect(result).toContain("Moon: 0°00' Leo [Ruler: Sun], 4th house");
     });
 
     test('includes equal house positions correctly with degree', () => {
@@ -103,8 +103,8 @@ describe('Basic Formatting', () => {
       const result = chart2txt(data);
 
       expect(result).toContain('[PLANETS]');
-      expect(result).toContain('Sun: 5° Taurus [Ruler: Venus], 1st house');
-      expect(result).toContain('Moon: 0° Leo [Ruler: Sun], 4th house');
+      expect(result).toContain("Sun: 5°00' Taurus [Ruler: Venus], 1st house");
+      expect(result).toContain("Moon: 0°00' Leo [Ruler: Sun], 4th house");
     });
 
     test('includes whole sign house positions correctly with degree', () => {
@@ -123,8 +123,8 @@ describe('Basic Formatting', () => {
       });
 
       expect(result).toContain('[PLANETS]');
-      expect(result).toContain('Sun: 5° Taurus [Ruler: Venus], 2nd house');
-      expect(result).toContain('Moon: 0° Leo [Ruler: Sun], 5th house');
+      expect(result).toContain("Sun: 5°00' Taurus [Ruler: Venus], 2nd house");
+      expect(result).toContain("Moon: 0°00' Leo [Ruler: Sun], 5th house");
     });
 
     test('handles zodiac wraparound when 1st house cusp > 12th house cusp', () => {
@@ -145,19 +145,19 @@ describe('Basic Formatting', () => {
 
       expect(result).toContain('[PLANETS]');
       // Sun at 350° (20° Pisces) should be in 1st house (340°-10° wraparound)
-      expect(result).toContain('Sun: 20° Pisces [Ruler: Jupiter], 1st house');
+      expect(result).toContain("Sun: 20°00' Pisces [Ruler: Jupiter], 1st house");
       // Moon at 10° (10° Aries) should be in 2nd house (10°-40°)
-      expect(result).toContain('Moon: 10° Aries [Ruler: Mars], 2nd house');
+      expect(result).toContain("Moon: 10°00' Aries [Ruler: Mars], 2nd house");
       // Mercury at 320° (20° Aquarius) should be in 12th house (310°-340°)
       expect(result).toContain(
-        'Mercury: 20° Aquarius [Ruler: Saturn], 12th house'
+        "Mercury: 20°00' Aquarius [Ruler: Saturn], 12th house"
       );
       // Venus at 40° (10° Taurus) should be in 3rd house (40°-70°)
-      expect(result).toContain('Venus: 10° Taurus [Domicile], 3rd house');
+      expect(result).toContain("Venus: 10°00' Taurus [Domicile], 3rd house");
 
       expect(result).toContain('[HOUSE CUSPS]');
-      expect(result).toContain('1st house: 10° Pisces'); // 340° = 10° Pisces
-      expect(result).toContain('12th house: 10° Aquarius'); // 310° = 10° Aquarius
+      expect(result).toContain("1st house: 10°00' Pisces"); // 340° = 10° Pisces
+      expect(result).toContain("12th house: 10°00' Aquarius"); // 310° = 10° Aquarius
     });
   });
 
@@ -174,7 +174,7 @@ describe('Basic Formatting', () => {
       const result = chart2txt(data, { includeAspectPatterns: true });
 
       expect(result).toContain('[ANGLES]');
-      expect(result).toContain('Ascendant: 6° Aries');
+      expect(result).toContain("Ascendant: 6°00' Aries");
     });
 
     test('formats midheaven correctly', () => {
@@ -190,8 +190,8 @@ describe('Basic Formatting', () => {
       const result = chart2txt(data, { includeAspectPatterns: true });
 
       expect(result).toContain('[ANGLES]');
-      expect(result).toContain('Ascendant: 6° Aries');
-      expect(result).toContain('Midheaven: 0° Leo');
+      expect(result).toContain("Ascendant: 6°00' Aries");
+      expect(result).toContain("Midheaven: 0°00' Leo");
     });
 
     test('omits midheaven when not provided', () => {
@@ -206,7 +206,7 @@ describe('Basic Formatting', () => {
       const result = chart2txt(data, { includeAspectPatterns: true });
 
       expect(result).toContain('[ANGLES]');
-      expect(result).toContain('Ascendant: 6° Aries');
+      expect(result).toContain("Ascendant: 6°00' Aries");
       expect(result).toContain('Midheaven: Not available');
     });
   });
@@ -289,10 +289,10 @@ describe('Basic Formatting', () => {
       const result = chart2txt(data, { includeAspectPatterns: true });
 
       expect(result).toContain('[HOUSE CUSPS]');
-      expect(result).toContain('1st house: 0° Aries');
-      expect(result).toContain('7th house: 0° Libra');
-      expect(result).toContain('2nd house: 0° Taurus');
-      expect(result).toContain('8th house: 0° Scorpio');
+      expect(result).toContain("1st house: 0°00' Aries");
+      expect(result).toContain("7th house: 0°00' Libra");
+      expect(result).toContain("2nd house: 0°00' Taurus");
+      expect(result).toContain("8th house: 0°00' Scorpio");
     });
 
     test('handles missing house cusps', () => {
@@ -317,10 +317,10 @@ describe('Basic Formatting', () => {
       const result = chart2txt(data, { includeAspectPatterns: true });
 
       expect(result).toContain('[HOUSE CUSPS]');
-      expect(result).toContain('1st house: 15° Aries');
-      expect(result).toContain('7th house: 15° Libra');
-      expect(result).toContain('4th house: 15° Cancer');
-      expect(result).toContain('10th house: 15° Capricorn');
+      expect(result).toContain("1st house: 15°00' Aries");
+      expect(result).toContain("7th house: 15°00' Libra");
+      expect(result).toContain("4th house: 15°00' Cancer");
+      expect(result).toContain("10th house: 15°00' Capricorn");
     });
   });
 
@@ -339,10 +339,10 @@ describe('Basic Formatting', () => {
       const result = chart2txt(data, { includeAspectPatterns: true });
 
       expect(result).toContain('[PLANETS]');
-      expect(result).toContain('Sun: 0° Leo [Domicile], 5th house');
-      expect(result).toContain('Moon: 0° Cancer [Domicile], 4th house');
+      expect(result).toContain("Sun: 0°00' Leo [Domicile], 5th house");
+      expect(result).toContain("Moon: 0°00' Cancer [Domicile], 4th house");
       expect(result).toContain(
-        'Mercury: 0° Virgo [Domicile, Exaltation], 6th house'
+        "Mercury: 0°00' Virgo [Domicile, Exaltation], 6th house"
       );
     });
 
@@ -358,8 +358,8 @@ describe('Basic Formatting', () => {
       const result = chart2txt(data, { includeAspectPatterns: true });
 
       expect(result).toContain('[PLANETS]');
-      expect(result).toContain('Sun: 0° Capricorn [Ruler: Saturn]');
-      expect(result).toContain('Mars: 0° Cancer [Fall | Ruler: Moon]');
+      expect(result).toContain("Sun: 0°00' Capricorn [Ruler: Saturn]");
+      expect(result).toContain("Mars: 0°00' Cancer [Fall | Ruler: Moon]");
     });
 
     test('formats planets with exaltation', () => {
@@ -374,8 +374,8 @@ describe('Basic Formatting', () => {
       const result = chart2txt(data, { includeAspectPatterns: true });
 
       expect(result).toContain('[PLANETS]');
-      expect(result).toContain('Sun: 0° Aries [Exaltation | Ruler: Mars]');
-      expect(result).toContain('Moon: 0° Taurus [Exaltation | Ruler: Venus]');
+      expect(result).toContain("Sun: 0°00' Aries [Exaltation | Ruler: Mars]");
+      expect(result).toContain("Moon: 0°00' Taurus [Exaltation | Ruler: Venus]");
     });
 
     test('formats planets with mixed dignities and retrograde', () => {
@@ -392,10 +392,10 @@ describe('Basic Formatting', () => {
 
       expect(result).toContain('[PLANETS]');
       expect(result).toContain(
-        'Mercury: 0° Virgo Retrograde [Domicile, Exaltation], 6th house'
+        "Mercury: 0°00' Virgo Retrograde [Domicile, Exaltation], 6th house"
       );
       expect(result).toContain(
-        'Venus: 0° Libra Retrograde [Domicile], 7th house'
+        "Venus: 0°00' Libra Retrograde [Domicile], 7th house"
       );
     });
   });

--- a/tests/basic-formatting.test.ts
+++ b/tests/basic-formatting.test.ts
@@ -19,6 +19,27 @@ describe('Basic Formatting', () => {
       expect(result).toContain("Moon: 0°00' Leo");
       expect(result).toContain("Mercury: 15°00' Gemini");
     });
+
+    test('renders arcminutes for fractional degrees', () => {
+      const data: ChartData = {
+        name: 'test',
+        ascendant: 12.5, // 12°30' Aries
+        midheaven: 123.25, // 3°15' Leo
+        planets: [
+          { name: 'Sun', degree: 45.5 }, // 15°30' Taurus
+          { name: 'Moon', degree: 359.99 }, // 29°59' Pisces (floored, not rounded)
+          { name: 'Mars', degree: 200.75 }, // 20°45' Libra
+        ],
+      };
+
+      const result = chart2txt(data);
+
+      expect(result).toContain("Sun: 15°30' Taurus");
+      expect(result).toContain("Moon: 29°59' Pisces");
+      expect(result).toContain("Mars: 20°45' Libra");
+      expect(result).toContain("Ascendant: 12°30' Aries");
+      expect(result).toContain("Midheaven: 3°15' Leo");
+    });
   });
 
   describe('house formatting', () => {

--- a/tests/basic-formatting.test.ts
+++ b/tests/basic-formatting.test.ts
@@ -28,7 +28,7 @@ describe('Basic Formatting', () => {
         planets: [
           { name: 'Sun', degree: 45.5 }, // 15°30' Taurus
           { name: 'Moon', degree: 359.99 }, // 29°59' Pisces (floored, not rounded)
-          { name: 'Mars', degree: 200.75 }, // 20°45' Libra
+          { name: 'Mars', degree: 200 + 1 / 60 }, // 20°01' Libra
         ],
       };
 
@@ -36,7 +36,7 @@ describe('Basic Formatting', () => {
 
       expect(result).toContain("Sun: 15°30' Taurus");
       expect(result).toContain("Moon: 29°59' Pisces");
-      expect(result).toContain("Mars: 20°45' Libra");
+      expect(result).toContain("Mars: 20°01' Libra");
       expect(result).toContain("Ascendant: 12°30' Aries");
       expect(result).toContain("Midheaven: 3°15' Leo");
     });

--- a/tests/composite-output.test.ts
+++ b/tests/composite-output.test.ts
@@ -36,8 +36,8 @@ describe('Composite Output Mode', () => {
     expect(result).toContain('source_charts: Alice, Bob');
     expect(result).toContain('[COMPOSITE: Alice-Bob]');
     expect(result).toContain('[PLANETS]');
-    expect(result).toContain('Sun: 0° Aries');
-    expect(result).toContain('Moon: 0° Leo');
+    expect(result).toContain("Sun: 0°00' Aries");
+    expect(result).toContain("Moon: 0°00' Leo");
 
     expect(result).not.toContain('[SYNASTRY:');
     expect(result).not.toContain('[HOUSE OVERLAYS]');

--- a/tests/grandTrineDeduplication.test.ts
+++ b/tests/grandTrineDeduplication.test.ts
@@ -78,10 +78,10 @@ describe('Grand Trine Deduplication in Kites', () => {
 
       // Should contain the Kite pattern
       expect(result).toContain('Kite (Fire');
-      expect(result).toContain("Person1's Sun 0° Aries");
-      expect(result).toContain("Person1's Moon 0° Leo");
-      expect(result).toContain("Person2's Mars 0° Sagittarius");
-      expect(result).toContain("Person2's Saturn 0° Libra");
+      expect(result).toContain("Person1's Sun 0°00' Aries");
+      expect(result).toContain("Person1's Moon 0°00' Leo");
+      expect(result).toContain("Person2's Mars 0°00' Sagittarius");
+      expect(result).toContain("Person2's Saturn 0°00' Libra");
 
       // Verify the composite section exists and check its contents
       const compositeSectionStart = result.indexOf(
@@ -128,9 +128,9 @@ describe('Grand Trine Deduplication in Kites', () => {
 
       // Should contain the standalone Grand Trine in composite section
       expect(result).toContain('Grand Trine (Fire');
-      expect(result).toContain("Person1's Sun 0° Aries");
-      expect(result).toContain("Person1's Moon 0° Leo");
-      expect(result).toContain("Person2's Mars 0° Sagittarius");
+      expect(result).toContain("Person1's Sun 0°00' Aries");
+      expect(result).toContain("Person1's Moon 0°00' Leo");
+      expect(result).toContain("Person2's Mars 0°00' Sagittarius");
 
       // Should NOT contain a Kite (no opposition)
       expect(result).not.toContain('Kite (');
@@ -150,7 +150,7 @@ describe('Grand Trine Deduplication in Kites', () => {
       const bob: ChartData = {
         name: 'Bob',
         planets: [
-          { name: 'Saturn', degree: 180 }, // 0° Libra (opposition to Alice\'s Sun = Kite)
+          { name: 'Saturn', degree: 180 }, // 0° Libra (opposition to Alice's Sun = Kite)
         ],
         houseCusps: [0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330],
       };

--- a/tests/multiChartAspectPatterns.test.ts
+++ b/tests/multiChartAspectPatterns.test.ts
@@ -113,7 +113,7 @@ describe('MultiChart Aspect Pattern Detection', () => {
         '[ASPECT PATTERNS: Person A-Person B Composite]'
       );
       expect(result).toContain('T-Square (');
-      expect(result).toContain("Person B's Mars 0° Cancer");
+      expect(result).toContain("Person B's Mars 0°00' Cancer");
     });
 
     it('should format a global Grand Trine correctly', () => {
@@ -141,7 +141,7 @@ describe('MultiChart Aspect Pattern Detection', () => {
         '[ASPECT PATTERNS: Person A-Person B-Person C Global Composite]'
       );
       expect(result).toContain('Grand Trine (');
-      expect(result).toContain("Person A's Sun 0° Aries");
+      expect(result).toContain("Person A's Sun 0°00' Aries");
     });
   });
 });

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -14,8 +14,8 @@ describe('Validation and Edge Cases', () => {
 
       const result = chart2txt(data);
 
-      expect(result).toContain('Sun: 0° Pisces'); // -30° + 360° = 330° = 0° Pisces
-      expect(result).toContain('Moon: 0° Capricorn'); // -90° + 360° = 270° = 0° Capricorn
+      expect(result).toContain("Sun: 0°00' Pisces"); // -30° + 360° = 330° = 0° Pisces
+      expect(result).toContain("Moon: 0°00' Capricorn"); // -90° + 360° = 270° = 0° Capricorn
     });
 
     test('handles degrees >= 360 correctly', () => {
@@ -29,8 +29,8 @@ describe('Validation and Edge Cases', () => {
 
       const result = chart2txt(data);
 
-      expect(result).toContain('Sun: 0° Taurus');
-      expect(result).toContain('Moon: 0° Cancer');
+      expect(result).toContain("Sun: 0°00' Taurus");
+      expect(result).toContain("Moon: 0°00' Cancer");
     });
 
     test('handles extreme degree values correctly', () => {
@@ -44,8 +44,8 @@ describe('Validation and Edge Cases', () => {
 
       const result = chart2txt(data);
 
-      expect(result).toContain('Sun: 0° Aries');
-      expect(result).toContain('Moon: 0° Aries');
+      expect(result).toContain("Sun: 0°00' Aries");
+      expect(result).toContain("Moon: 0°00' Aries");
     });
   });
 
@@ -140,8 +140,8 @@ describe('Validation and Edge Cases', () => {
       const result = chart2txt(data);
 
       // Planets exactly on cusps should be assigned to the house starting at that cusp
-      expect(result).toContain('Sun: 0° Taurus [Ruler: Venus], 2nd house');
-      expect(result).toContain('Moon: 0° Gemini [Ruler: Mercury], 3rd house');
+      expect(result).toContain("Sun: 0°00' Taurus [Ruler: Venus], 2nd house");
+      expect(result).toContain("Moon: 0°00' Gemini [Ruler: Mercury], 3rd house");
     });
 
     test('handles house wraparound at 0°/360° boundary consistently', () => {
@@ -157,10 +157,10 @@ describe('Validation and Edge Cases', () => {
 
       const result = chart2txt(data);
 
-      expect(result).toContain('Sun: 20° Pisces [Ruler: Jupiter], 1st house');
-      expect(result).toContain('Moon: 10° Aries [Ruler: Mars], 2nd house');
+      expect(result).toContain("Sun: 20°00' Pisces [Ruler: Jupiter], 1st house");
+      expect(result).toContain("Moon: 10°00' Aries [Ruler: Mars], 2nd house");
       expect(result).toContain(
-        'Mercury: 20° Aquarius [Ruler: Saturn], 12th house'
+        "Mercury: 20°00' Aquarius [Ruler: Saturn], 12th house"
       );
     });
   });
@@ -178,7 +178,7 @@ describe('Validation and Edge Cases', () => {
 
       // Mercury should show both detriment and fall in Pisces
       expect(result).toContain(
-        'Mercury: 0° Pisces [Detriment, Fall | Ruler: Jupiter]'
+        "Mercury: 0°00' Pisces [Detriment, Fall | Ruler: Jupiter]"
       );
     });
 
@@ -194,8 +194,8 @@ describe('Validation and Edge Cases', () => {
       const result = chart2txt(data);
 
       // Should not show fall information for signs that don't have it
-      expect(result).toContain('Sun: 0° Gemini [Ruler: Mercury]');
-      expect(result).toContain('Moon: 0° Sagittarius [Ruler: Jupiter]');
+      expect(result).toContain("Sun: 0°00' Gemini [Ruler: Mercury]");
+      expect(result).toContain("Moon: 0°00' Sagittarius [Ruler: Jupiter]");
       expect(result).not.toContain('Fall:');
     });
   });
@@ -214,8 +214,8 @@ describe('Validation and Edge Cases', () => {
       const result = chart2txt(data);
 
       // Both should be handled consistently despite tiny differences
-      expect(result).toContain('Sun: 29° Aries');
-      expect(result).toContain('Moon: 0° Taurus');
+      expect(result).toContain("Sun: 29°59' Aries");
+      expect(result).toContain("Moon: 0°00' Taurus");
       // House assignments should be consistent
       expect(result).toContain('1st house');
       expect(result).toContain('2nd house');

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -237,6 +237,23 @@ describe('Validation and Edge Cases', () => {
       expect(result).not.toContain("30°00'");
     });
 
+    test('renders exact sign boundaries (degree=30, 60, 360) as 0°00 of the next sign', () => {
+      const data: ChartData = {
+        name: 'test',
+        planets: [
+          { name: 'Sun', degree: 30 }, // exact Aries→Taurus boundary
+          { name: 'Moon', degree: 60 }, // exact Taurus→Gemini boundary
+          { name: 'Mars', degree: 360 }, // wraps to 0° Aries
+        ],
+      };
+
+      const result = chart2txt(data);
+
+      expect(result).toContain("Sun: 0°00' Taurus");
+      expect(result).toContain("Moon: 0°00' Gemini");
+      expect(result).toContain("Mars: 0°00' Aries");
+    });
+
     test('handles aspects with very tight orbs consistently', () => {
       const data: ChartData = {
         name: 'test',

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -221,6 +221,22 @@ describe('Validation and Edge Cases', () => {
       expect(result).toContain('2nd house');
     });
 
+    test('does not round positive values just below a sign boundary into the next sign', () => {
+      const data: ChartData = {
+        name: 'test',
+        planets: [
+          { name: 'Sun', degree: 29.999999999999996 },
+          { name: 'Moon', degree: 359.99999999999994 },
+        ],
+      };
+
+      const result = chart2txt(data);
+
+      expect(result).toContain("Sun: 29°59' Aries");
+      expect(result).toContain("Moon: 29°59' Pisces");
+      expect(result).not.toContain("30°00'");
+    });
+
     test('handles aspects with very tight orbs consistently', () => {
       const data: ChartData = {
         name: 'test',


### PR DESCRIPTION
## Summary
- Positions in `[PLANETS]`, `[ANGLES]`, `[HOUSE CUSPS]`, and `[ASPECT PATTERNS]` now print as `15°23' Aries` instead of truncating to `15° Aries`.
- New helper `formatDegMin(degreeInSign)` in `src/utils/formatting.ts` — floors to whole arcminutes, zero-pads minutes for column alignment.
- All 4 text-formatter call sites routed through it.
- Tests updated to match new format (107 passing).
- Version bump 0.8.3 → 0.9.0 (minor: visible output format change).

## Notes
- Git history shows this is actually new behavior, not a restoration — even the initial commit truncated to whole degrees. Treating as "add" rather than "restore."
- Underlying `degree` numbers always carried full precision; only the final formatter dropped minutes.
- House-cusp column padding bumped 24→28 to fit the extra `MM'` characters.

## Test plan
- [x] `npm test` — 107/107 pass
- [x] `npm run build` — clean
- [ ] Visual sanity check on a real chart via chart2ai once published

🤖 Generated with [Claude Code](https://claude.com/claude-code)